### PR TITLE
Fix spelling errors and wording

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -1,7 +1,18 @@
+rep_robj_xsrl_root_create_xsrl#:#Lernort anlegen
+rep_robj_xsrl_cat_create_xsrl#:#Lernort anlegen
+rep_robj_xsrl_crs_create_xsrl#:#Lernort anlegen
+rep_robj_xsrl_grp_create_xsrl#:#Lernort anlegen
+rep_robj_xsrl_fold_create_xsrl#:#Lernort anlegen
+rep_robj_xsrl_xsrl_visible#:#Anzeigen: Lernort ist sichtbar
+rep_robj_xsrl_xsrl_read#:#Lesezugriff: Lernort lesen
+rep_robj_xsrl_xsrl_write#:#Einstellungen bearbeiten: Lernort bearbeiten
+rep_robj_xsrl_xsrl_delete#:#L&ouml;schen: Lernort l&ouml;schen
+rep_robj_xsrl_xsrl_edit_permission#:#Rechteeinstellungen &auml;ndern: Rechteeinstellungen &auml;ndern
+
 objs_xsrl#:#Lernorte
-objs_xsrl_duplicate#:#Kopiere bestehender Lernort
+objs_xsrl_duplicate#:#Kopiere bestehenden Lernort
 obj_xsrl#:#Lernort
-xsrl_new#:#Neuer Lernort erstellen
+xsrl_new#:#Neuen Lernort erstellen
 
 xsrl_add#:#Erstellen
 
@@ -29,17 +40,17 @@ tabs_edit#:#Block bearbeiten
 tabs_settings#:#Einstellungen
 tabs_map#:#Karte
 
-block_specific_settings#:#Block spezifische Einstellungen
-picture_upload_block_content#:#Bildupload Block
+block_specific_settings#:#Block-spezifische Einstellungen
+picture_upload_block_content#:#Bild-Upload
 
-confirm_delete_header#:#Achtung, der block wird unwiderruflich gel&ouml;scht!
+confirm_delete_header#:#Achtung, der Block wird unwiderruflich gel&ouml;scht!
 
-block_rich_text#:#Rich text
+block_rich_text#:#Text
 block_map#:#Karte
-block_ilias_link#:#ILIAS link
+block_ilias_link#:#Link zu einem ILIAS-Objekt im Magazin
 block_accordion#:#Akkordeon
 block_picture#:#Bild
-block_picture_upload#:#Bilderupload
+block_picture_upload#:#Bild-Upload
 block_video#:#Video
 block_type_title#:#Verf&uuml;gbare Bl&ouml;cke:
 block_add_header#:#Block hinzuf&uuml;gen
@@ -47,33 +58,33 @@ block_add_header#:#Block hinzuf&uuml;gen
 picture_block_enter_title#:#Titel
 picture_block_enter_description#:#Beschreibung
 picture_block_select_picture#:#Bild
-picture_block_upload_error#:#Bilderupload unvollst&auml;ndig oder das Format wird nicht unterst&uuml;tzt.
+picture_block_upload_error#:#Bild-Upload unvollst&auml;ndig oder das Format wird nicht unterst&uuml;tzt.
 
 video_block_select_video#:#Video
-video_block_upload_error#:#Videoupload unvollst&auml;ndig oder das Format wird nicht unterst&uuml;tzt.
+video_block_upload_error#:#Video-Upload unvollst&auml;ndig oder das Format wird nicht unterst&uuml;tzt.
 
 rich_text_block_content#:#Inhalt
 
-ilias_link_block_select_target#:#ILIAS link
+ilias_link_block_select_target#:#ILIAS-Link
 
 accordion_block_title#:#Titel
 accordion_block_expand#:#Akkordeon ge&ouml;ffnet
 
 visibility_title#:#Verfügbare Sichtbarkeiten:
 visibility_always#:#Immer sichtbar
-visibility_after_visit_place#:#Nur sichtbar nach Lernort Besuch
+visibility_after_visit_place#:#Nur sichtbar vor Ort und nach Besuch des Lernorts
 visibility_only_at_place#:#Nur sichtbar vor Ort
 visibility_never#:#Nie sichtbar
 
 setting_location#:#Position
 setting_general#:#Allgemein
 setting_radius#:#Radius
-setting_radius_info#:#Der Radius wird in Metern angegeben und bestimmt wie gross das Umfeld des Lernortes ist. Es wird generell empfohlen den Wert von 50 Metern nicht zu unterschreiten. Der minimum Radius beträgt 1 Meter und der maximale 40'000 Meter.
-setting_validation_failure_radius#:#Ein g&uuml;tiger Radius befindet sich zwischen 1 und 40'000 Meter.
-setting_visibility_default#:#Standart Sichtbarkeit
+setting_radius_info#:#Der Radius wird in Metern angegeben und bestimmt wie gro&szlig; das Umfeld des Lernortes ist. Es wird generell empfohlen den Wert von 50 Metern nicht zu unterschreiten. Der minimale Radius beträgt 1 Meter und der maximale 40.000 Meter.
+setting_validation_failure_radius#:#Ein g&uuml;ltiger Radius liegt zwischen 1 und 40.000 Metern.
+setting_visibility_default#:#Standard-Sichtbarkeit
 
 content_save_sequence#:#Reihenfolge speichern
 
 news_created#:#Lernort wurde erstellt.
-news_updated#:#Lernort Einstellungen wurden aktualisiert.
+news_updated#:#Lernort-Einstellungen wurden aktualisiert.
 news_deleted#:#Lernort wurde gel&ouml;scht.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -19,8 +19,8 @@ xsrl_add#:#Erstellen
 common_create#:#Erstellen
 common_status#:#Status
 common_cancel#:#Abbrechen
-common_offline#:#Inaktiv
-common_online#:#Aktiv
+common_offline#:#Offline
+common_online#:#Online
 common_add#:#Hinzuf&uuml;gen
 common_edit#:#Bearbeiten
 common_save#:#Speichern


### PR DESCRIPTION
Fix some spelling errors, improve ambiguous wording and add missing variables for right settings (for more information see https://docu.ilias.de/goto_docu_wiki_wpage_6050_6052.html).